### PR TITLE
Fix build breakers on Linux

### DIFF
--- a/sources/camera.cpp
+++ b/sources/camera.cpp
@@ -4,9 +4,11 @@
 #include <SDL2/SDL.h>
 #include <glm/gtx/transform.hpp>
 #include <glm/ext.hpp>
+#include <glm/gtx/string_cast.hpp>
 
 #include <algorithm>
 #include <iostream>
+#include <string>
 
 #define FREE_CAM
 #ifdef __EMSCRIPTEN__

--- a/sources/camera.cpp
+++ b/sources/camera.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <string>
 
 #define FREE_CAM
 #ifdef __EMSCRIPTEN__


### PR DESCRIPTION
Hello,

Thanks for sharing your code !

Two headers were not included, and the changes to fix the build are inside. Everything is under the MIT Licence, just in case you will accept the PR.

Last but not least. Where are the missing assets ? Got a segfault in runtime because missing assets (examples ?) 

````
 $ ./Particle
OpenGL loaded
Vendor:   Intel Open Source Technology Center
Renderer: Mesa DRI Intel(R) UHD Graphics 620 (WHL GT2)
Version:  4.6 (Compatibility Profile) Mesa 21.2.0-devel (git-a1c56b8091)
Audio: freq 48000, format 33056, channels 2, samples 2048 
Open file ../asset/mesh/plane.assxml rb
File not found
Erreur de segmentation (core dumped)

````


Thanks in advance,
Eric Bachard
